### PR TITLE
Add macros and sample models

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -19,3 +19,10 @@ clean-targets:
 models:
   sample_dbt:
     +materialized: view
+    +schema: "{{ generate_schema_name_with_env(this.schema) }}"
+    staging:
+        +materialized: view
+        +schema: "{{ generate_schema_name_with_env('staging') }}"
+    marts:
+        +materialized: table
+        +schema: "{{ generate_schema_name_with_env('marts') }}"

--- a/macros/utils.sql
+++ b/macros/utils.sql
@@ -1,0 +1,25 @@
+{% macro generate_schema_name_with_env(custom_schema_name) %}
+    {%- if target.name == 'dev' -%}
+        {{ custom_schema_name }}_dev
+    {%- elif target.name == 'prod' -%}
+        {{ custom_schema_name }}_prod
+    {%- else -%}
+        {{ custom_schema_name }}_default
+    {%- endif -%}
+{% endmacro %}
+
+{% macro get_payment_type_description(payment_type_column) %}
+    case {{ payment_type_column }}
+        when 1 then 'Credit Card'
+        when 2 then 'Bank Transfer'
+        when 3 then 'Cash on Delivery'
+        when 4 then 'Coupon'
+        else 'Other'
+    end
+{% endmacro %}
+
+{% macro add_audit_columns(created_at_alias='created_at', updated_at_alias='updated_at') %}
+    current_timestamp as {{ created_at_alias }},
+    current_timestamp as {{ updated_at_alias }}
+{% endmacro %}
+

--- a/models/marts/fct_orders_with_details.sql
+++ b/models/marts/fct_orders_with_details.sql
@@ -1,0 +1,15 @@
+with payments as (
+    select * from {{ ref('stg_payments') }}
+)
+
+select
+    order_id,
+    amount,
+    payment_type_code,
+    {{ get_payment_type_description('payment_type_code') }} as payment_method_description,
+    {{ add_audit_columns(created_at_alias='order_processed_at', updated_at_alias='last_checked_at') }}
+from
+    payments
+where
+    amount > 0
+

--- a/models/marts/schema.yml
+++ b/models/marts/schema.yml
@@ -15,3 +15,9 @@ models:
         tests:
           - not_null
           - unique
+  - name: fct_orders_with_details
+    description: "受注ファクトに支払い詳細を付与"
+    columns:
+      - name: order_id
+        tests:
+          - not_null

--- a/models/staging/schema.yml
+++ b/models/staging/schema.yml
@@ -8,3 +8,9 @@ models:
         tests:
           - not_null
           - unique
+  - name: stg_payments
+    description: "支払いデータをステージング"
+    columns:
+      - name: order_id
+        tests:
+          - not_null

--- a/models/staging/stg_payments.sql
+++ b/models/staging/stg_payments.sql
@@ -1,0 +1,19 @@
+with raw_payments as (
+    select 1 as order_id, 1 as payment_type_code, 1000 as amount
+    union all
+    select 2 as order_id, 2 as payment_type_code, 2500 as amount
+    union all
+    select 3 as order_id, 1 as payment_type_code, 500 as amount
+    union all
+    select 4 as order_id, 3 as payment_type_code, 1200 as amount
+    union all
+    select 5 as order_id, 5 as payment_type_code, 300 as amount
+)
+
+select
+    order_id,
+    payment_type_code,
+    amount
+from
+    raw_payments
+


### PR DESCRIPTION
## Summary
- マクロで環境別スキーマ名を生成
- 支払いタイプ説明や監査カラムを返すマクロを実装
- サンプルの支払いステージングモデルを追加
- 支払い詳細付きのファクトモデルを追加
- dbt_project.yml をマクロ利用に合わせて更新
- schema.yml に新規モデルを追記

## Testing
- `poetry install` *(失敗: ネットワークに接続できず)*
- `poetry run dbt compile` *(失敗: コマンドが見つからず)*


------
https://chatgpt.com/codex/tasks/task_e_683ab8b71f808329b9d01400623224e3